### PR TITLE
Tree improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ project/plugins/project/
 .project
 .settings/
 .cache
+
+.idea/
+.idea_modules/

--- a/build.sbt
+++ b/build.sbt
@@ -2,15 +2,18 @@ name := "ScalaSwingContrib"
 
 organization := "com.github.benhutchison"
 
-version := "1.4"
+version := "1.5-SNAPSHOT"
 
 scalaVersion := "2.10.0"
 
+libraryDependencies <+= scalaVersion { sv => "org.scala-lang" % "scala-swing" % sv }
+
 libraryDependencies ++= Seq(
-  "org.scala-lang" % "scala-swing" % "2.10.0",
   "org.specs2" %% "specs2" % "1.13" % "test",
   "junit" % "junit" % "4.7" % "test"
 )
+
+scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature")
 
 crossPaths := false
 

--- a/project/gpg.sbt
+++ b/project/gpg.sbt
@@ -1,3 +1,1 @@
-resolvers += Resolver.url("sbt-plugin-releases", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)
-
-addSbtPlugin("com.jsuereth" % "xsbt-gpg-plugin" % "0.6")
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.7")

--- a/src/main/scala/scalaswingcontrib/CellEditor.scala
+++ b/src/main/scala/scalaswingcontrib/CellEditor.scala
@@ -1,11 +1,12 @@
 package scalaswingcontrib
-import scala.swing.Publisher
+
+import swing.Publisher
 
 /**
 * Common superclass of cell editors.
 * @author Ken Scambler
 */
-trait CellEditor[A] extends Publisher {
+trait CellEditor[+A] extends Publisher {
   def peer: AnyRef
   def value: A
   def cellEditable: Boolean

--- a/src/main/scala/scalaswingcontrib/CellView.scala
+++ b/src/main/scala/scalaswingcontrib/CellView.scala
@@ -1,14 +1,14 @@
 package scalaswingcontrib
 
-import scala.swing.{Component, Publisher}
-import scala.collection.{mutable, Iterator, Seq}
+import swing.{Component, Publisher}
+import collection.mutable
 
 /**
 * Describes components that have a concept of a "cell", each of which contains a value, may be selected, 
 * and may support pluggable Renderers and Editors.
 */
 trait CellView[+A] {
-  this: Component =>
+  _: Component =>
     
   def editable: Boolean 
   def cellValues: Iterator[A]
@@ -32,7 +32,7 @@ trait CellView[+A] {
       override def size = nonNullOrEmpty(a).length
       def contains(s: S) = nonNullOrEmpty(a) contains s
       def iterator = nonNullOrEmpty(a).iterator
-      protected def nonNullOrEmpty[A](s: Seq[A]) = if (s != null) s else Seq.empty
+      protected def nonNullOrEmpty[A1](s: Seq[A1]) = if (s != null) s else Seq.empty
     }
     
     /**
@@ -43,22 +43,22 @@ trait CellView[+A] {
     /**
     * Whether or not the current selection is empty.
     */
-    def empty: Boolean
+    def isEmpty: Boolean
     
     /**
     * Returns the number of cells currently selected.
     */
-    def count: Int
+    def size: Int
   } 
   
-  val selection: CellSelection
+  def selection: CellSelection
 }
 
 /**
 * This should be mixed in to CellView implementations that support pluggable renderers.
 */
 trait RenderableCells[A] {
-  this: CellView[A] =>
+  _: CellView[A] =>
   val companion: RenderableCellsCompanion
   def renderer: companion.Renderer[A]
   def renderer_=(r: companion.Renderer[A]): Unit
@@ -68,7 +68,7 @@ trait RenderableCells[A] {
 * This should be mixed in to CellView implementations that support pluggable editors.
 */
 trait EditableCells[A]  {
-  this: CellView[A] =>
+  _: CellView[A] =>
   val companion: EditableCellsCompanion
   def editor: companion.Editor[A]
   def editor_=(r: companion.Editor[A]): Unit

--- a/src/main/scala/scalaswingcontrib/EditableCellsCompanion.scala
+++ b/src/main/scala/scalaswingcontrib/EditableCellsCompanion.scala
@@ -1,10 +1,10 @@
 package scalaswingcontrib
 
-import scala.swing.{Component, Publisher}
+import swing.{Component, Publisher}
 import scalaswingcontrib.event.{CellEditingCancelled, CellEditingStopped}
 import javax.{swing => js}
 import javax.swing.{event => jse}
-import scala.language.higherKinds
+import language.higherKinds
 
 /**
 * Describes the structure of a component's companion object where pluggable cell editors must be supported.
@@ -30,7 +30,7 @@ trait EditableCellsCompanion {
     def peer: companion.Peer
 
     protected def fireCellEditingCancelled() { publish(CellEditingCancelled(CellEditor.this)) }
-    protected def fireCellEditingStopped() { publish(CellEditingStopped(CellEditor.this)) }
+    protected def fireCellEditingStopped()   { publish(CellEditingStopped(  CellEditor.this)) }
 
     protected def listenToPeer(p: js.CellEditor) {
       p.addCellEditorListener(new jse.CellEditorListener {
@@ -40,15 +40,15 @@ trait EditableCellsCompanion {
     }
 
     abstract class EditorPeer extends js.AbstractCellEditor {
-      override def getCellEditorValue(): AnyRef = value.asInstanceOf[AnyRef]
+      override def getCellEditorValue: AnyRef = value.asInstanceOf[AnyRef]
       listenToPeer(this)
     }
 
     def componentFor(owner: Owner, value: A, cellInfo: companion.CellInfo): Component
     
-    def cellEditable = peer.isCellEditable(null)
-    def shouldSelectCell = peer.shouldSelectCell(null)
-    def cancelCellEditing() = peer.cancelCellEditing
-    def stopCellEditing() = peer.stopCellEditing
+    def cellEditable        = peer.isCellEditable(null)
+    def shouldSelectCell    = peer.shouldSelectCell(null)
+    def cancelCellEditing() { peer.cancelCellEditing() }
+    def stopCellEditing()   = peer.stopCellEditing
   }
 }

--- a/src/main/scala/scalaswingcontrib/RenderableCellsCompanion.scala
+++ b/src/main/scala/scalaswingcontrib/RenderableCellsCompanion.scala
@@ -1,8 +1,8 @@
 package scalaswingcontrib
 
-import scala.swing.{Label, Component, Publisher}
+import swing.{Label, Component, Publisher}
 import javax.{swing => js}
-import scala.language.higherKinds
+import language.higherKinds
 
 /**
 * Describes the structure of a component's companion object where pluggable cell renderers must be supported.
@@ -40,7 +40,7 @@ trait RenderableCellsCompanion {
     /**
     * Convenient default display of a cell node, which provides an Icon and label text for each item.
     */
-    def labelled[A](f: A => (js.Icon, String)): DefaultRenderer[A]
+    def labeled[A](f: A => (js.Icon, String)): DefaultRenderer[A]
     
     protected trait LabelRenderer[-A] extends CellRenderer[A] {
       this: DefaultRenderer[A] =>
@@ -56,7 +56,7 @@ trait RenderableCellsCompanion {
     }
   }
 
-  trait CellRenderer[-A] extends Publisher  { 
+  trait CellRenderer[-A] extends Publisher  {
     val companion: CellRendererCompanion
     def peer: companion.Peer
     def componentFor(owner: Owner, value: A, cellInfo: companion.CellInfo): Component

--- a/src/main/scala/scalaswingcontrib/event/CellEditorEvent.scala
+++ b/src/main/scala/scalaswingcontrib/event/CellEditorEvent.scala
@@ -1,11 +1,10 @@
 package scalaswingcontrib
 package event
 
-import scala.swing.event.Event
+import swing.event.Event
 
-
-trait CellEditorEvent[A] extends Event {
-  val source: CellEditor[A]
+sealed trait CellEditorEvent[+A] extends Event {
+  def source: CellEditor[A]
 }
-case class CellEditingStopped[A](source: CellEditor[A]) extends CellEditorEvent[A]
-case class CellEditingCancelled[A](source: CellEditor[A]) extends CellEditorEvent[A]
+final case class CellEditingStopped[A](  source: CellEditor[A]) extends CellEditorEvent[A]
+final case class CellEditingCancelled[A](source: CellEditor[A]) extends CellEditorEvent[A]

--- a/src/main/scala/scalaswingcontrib/event/TreeEvent.scala
+++ b/src/main/scala/scalaswingcontrib/event/TreeEvent.scala
@@ -1,11 +1,10 @@
 package scalaswingcontrib
 package event
 
-import scalaswingcontrib.tree.Tree
-import scala.swing.event.{ComponentEvent, SelectionEvent}
+import tree.Tree
+import swing.event.{SelectionEvent, ComponentEvent}
 
-
-trait TreeEvent[A] extends ComponentEvent {
+sealed trait TreeEvent[A] extends ComponentEvent {
   val source: Tree[A]
 }
 
@@ -16,26 +15,27 @@ object TreeNodeSelected {
   }
 }
 
-case class TreePathSelected[A](source: Tree[A], 
-        newPaths: List[Tree.Path[A]], 
-        oldPaths: List[Tree.Path[A]], 
-        newLeadSelectionPath: Option[Tree.Path[A]], 
-        oldLeadSelectionPath: Option[Tree.Path[A]]) extends TreeEvent[A] with SelectionEvent
+final case class TreePathSelected[A](source: Tree[A],
+                                     newPaths: List[Tree.Path[A]],
+                                     oldPaths: List[Tree.Path[A]],
+                                     newLeadSelectionPath: Option[Tree.Path[A]],
+                                     oldLeadSelectionPath: Option[Tree.Path[A]])
+  extends TreeEvent[A] with SelectionEvent
 
-trait TreeExpansionEvent[A] extends TreeEvent[A] {
-  val path: Tree.Path[A]
+sealed trait TreeExpansionEvent[A] extends TreeEvent[A] {
+  def path: Tree.Path[A]
 }
-case class TreeCollapsed[A](source: Tree[A], path: Tree.Path[A]) extends TreeExpansionEvent[A]
-case class TreeExpanded[A](source: Tree[A], path: Tree.Path[A]) extends TreeExpansionEvent[A]
-case class TreeWillCollapse[A](source: Tree[A], path: Tree.Path[A]) extends TreeExpansionEvent[A]
-case class TreeWillExpand[A](source: Tree[A], path: Tree.Path[A]) extends TreeExpansionEvent[A]
+final case class TreeCollapsed[A](   source: Tree[A], path: Tree.Path[A]) extends TreeExpansionEvent[A]
+final case class TreeExpanded[A](    source: Tree[A], path: Tree.Path[A]) extends TreeExpansionEvent[A]
+final case class TreeWillCollapse[A](source: Tree[A], path: Tree.Path[A]) extends TreeExpansionEvent[A]
+final case class TreeWillExpand[A](  source: Tree[A], path: Tree.Path[A]) extends TreeExpansionEvent[A]
 
-trait TreeModelEvent[A] extends TreeEvent[A] {
-    val path: Tree.Path[A]
-    val childIndices: List[Int]
-    val children: List[A]
+sealed trait TreeModelEvent[A] extends TreeEvent[A] {
+  def path: Tree.Path[A]
+  def childIndices: List[Int]
+  def children: List[A]
 }
-case class TreeNodesChanged[A](source: Tree[A], path: Tree.Path[A], childIndices: List[Int], children: List[A]) extends TreeModelEvent[A]
-case class TreeNodesInserted[A](source: Tree[A], path: Tree.Path[A], childIndices: List[Int], children: List[A]) extends TreeModelEvent[A]
-case class TreeNodesRemoved[A](source: Tree[A], path: Tree.Path[A], childIndices: List[Int], children: List[A]) extends TreeModelEvent[A]
-case class TreeStructureChanged[A](source: Tree[A], path: Tree.Path[A], childIndices: List[Int], children: List[A]) extends TreeModelEvent[A]
+final case class TreeNodesChanged[A](    source: Tree[A], path: Tree.Path[A], childIndices: List[Int], children: List[A]) extends TreeModelEvent[A]
+final case class TreeNodesInserted[A](   source: Tree[A], path: Tree.Path[A], childIndices: List[Int], children: List[A]) extends TreeModelEvent[A]
+final case class TreeNodesRemoved[A](    source: Tree[A], path: Tree.Path[A], childIndices: List[Int], children: List[A]) extends TreeModelEvent[A]
+final case class TreeStructureChanged[A](source: Tree[A], path: Tree.Path[A], childIndices: List[Int], children: List[A]) extends TreeModelEvent[A]

--- a/src/main/scala/scalaswingcontrib/test/TreeDemo.scala
+++ b/src/main/scala/scalaswingcontrib/test/TreeDemo.scala
@@ -1,15 +1,13 @@
 package scalaswingcontrib
 package test
 
-import scala.xml.{Node, XML}
-import scala.swing.{Button, Label, SimpleSwingApplication, Dimension, Component, 
-                    Action, GridPanel, MainFrame, TabbedPane, BorderPanel, ScrollPane}
-import scala.swing.Swing.{Icon, pair2Dimension}
+import xml.{Node, XML}
+import swing.{Button, Label, SimpleSwingApplication, Dimension, Component,
+                    Action, GridPanel, MainFrame, TabbedPane, BorderPanel, ScrollPane, Swing}
+import Swing.{Icon, pair2Dimension}
 import scalaswingcontrib.tree.{Tree, TreeModel, InternalTreeModel, ExternalTreeModel}
 import scalaswingcontrib.event.TreeNodeSelected
-import java.awt.Color
-import java.awt.{event => jae}
-import scala.collection.mutable
+import collection.mutable
 import Tree.{Renderer, Editor}
 
 object TreeDemo extends SimpleSwingApplication {
@@ -31,12 +29,12 @@ object TreeDemo extends SimpleSwingApplication {
   
   // Use case 2: Show the filesystem with filter
   lazy val fileSystemTree = new Tree[File] {
-    model = TreeModel(new File(".")) {f => 
+    model = TreeModel(new File(".")) { f =>
       if (f.isDirectory) f.listFiles.toSeq 
       else Seq()
     }
     
-    renderer = Renderer.labelled {f =>
+    renderer = Renderer.labeled { f =>
       val icon = if (f.isDirectory) folderIcon 
                  else fileIcon
       (icon, f.getName)
@@ -98,7 +96,7 @@ object TreeDemo extends SimpleSwingApplication {
       case TreeNodeSelected(node) => externalTreeStatusBar.text = "Selected: " + node
     }
     
-    renderer = Renderer.labelled  {f =>
+    renderer = Renderer.labeled { f =>
       val icon = if (f.isDirectory) folderIcon 
                  else fileIcon
       (icon, f.name)

--- a/src/main/scala/scalaswingcontrib/tree/InternalTreeModel.scala
+++ b/src/main/scala/scalaswingcontrib/tree/InternalTreeModel.scala
@@ -4,10 +4,9 @@ package tree
 import javax.swing.{tree => jst}
 import Tree.Path
 import TreeModel.hiddenRoot
-import scala.collection.JavaConversions.enumerationAsScalaIterator
-import scala.sys.error
+import collection.JavaConversions.enumerationAsScalaIterator
 import InternalTreeModel.{PeerModel, PeerNode}
-import scala.reflect.ClassTag
+import collection.breakOut
 
 object InternalTreeModel {
   
@@ -27,31 +26,30 @@ object InternalTreeModel {
   }
   
   private[tree] type PeerModel = jst.DefaultTreeModel
-  private[tree] type PeerNode = jst.DefaultMutableTreeNode
+  private[tree] type PeerNode  = jst.DefaultMutableTreeNode
 }
 
 
 class InternalTreeModel[A] private (val peer: PeerModel) extends TreeModel[A] { 
-  
   self =>
     
   def this() = this(new PeerModel(new PeerNode(hiddenRoot)))
     
-  def pathToTreePath(path: Tree.Path[A]): jst.TreePath = {
+  def pathToTreePath(path: Path[A]): jst.TreePath = {
     
     val nodePath = path.foldLeft(List(rootPeerNode)) { (pathList, a) => 
       val childNodes = getNodeChildren(pathList.head)
-      val node = childNodes.find(_.getUserObject == a) getOrElse error("Couldn't find internal node for " + a)
+      val node = childNodes.find(_.getUserObject == a) getOrElse sys.error("Couldn't find internal node for " + a)
       node :: pathList
     }.reverse
 
-    val array = nodePath.toArray(ClassTag.Object)
+    val array = nodePath.toArray[AnyRef]
     new jst.TreePath(array)
   }
 
-  def treePathToPath(tp: jst.TreePath): Tree.Path[A] = {
+  def treePathToPath(tp: jst.TreePath): Path[A] = {
     if (tp == null) null 
-    else (tp.getPath map unpackNode).tail.toIndexedSeq
+    else ((tp.getPath map unpackNode)(breakOut): Path[A]).tail
   } 
   
   private def rootPeerNode = peer.getRoot.asInstanceOf[PeerNode]
@@ -76,14 +74,14 @@ class InternalTreeModel[A] private (val peer: PeerModel) extends TreeModel[A] {
     true
   }
   
-  def map[B](f: A=>B): InternalTreeModel[B] = new InternalTreeModel[B] {
+  def map[B](f: A => B): InternalTreeModel[B] = new InternalTreeModel[B] {
     override val peer = copyFromModel(self, f)
   }
 
   protected[tree] def copyFromModel[B](otherModel: TreeModel[B], f: B => A): jst.DefaultTreeModel = {
     def copyNodeAt(bPath: Path[B]): PeerNode = {
-      val copiedNode = new PeerNode(f(bPath.last))
-      val otherChildren = otherModel.getChildrenOf(bPath)
+      val copiedNode     = new PeerNode(f(bPath.last))
+      val otherChildren  = otherModel.getChildrenOf(bPath)
       val copiedChildren = otherChildren map { b => copyNodeAt(bPath :+ b) }
       copiedChildren foreach copiedNode.add
       copiedNode

--- a/src/main/scala/scalaswingcontrib/tree/Tree.scala
+++ b/src/main/scala/scalaswingcontrib/tree/Tree.scala
@@ -1,22 +1,25 @@
 package scalaswingcontrib
 package tree
 
-import scalaswingcontrib.event.{TreeNodesInserted, TreeNodesRemoved, TreeStructureChanged, TreeNodesChanged, TreePathSelected}
-import scala.swing.{Color, Component, Label, Scrollable}
+import event.{TreeNodesInserted, TreeNodesRemoved, TreeStructureChanged, TreeNodesChanged, TreePathSelected}
+import swing.{Color, Component, Label, Scrollable}
 import java.{util => ju}
 import javax.{swing => js}
 import js.{tree => jst}
 import js.{event => jse}
-import scala.language.{implicitConversions, reflectiveCalls}
+import collection.breakOut
+import language.{implicitConversions, reflectiveCalls}
 
 sealed trait TreeEditors extends EditableCellsCompanion {
-  this: Tree.type => 
+  _: Tree.type =>
 
   protected override type Owner = Tree[_]
 
   object Editor extends CellEditorCompanion {
-    case class CellInfo(isSelected: Boolean = false, isExpanded: Boolean = false, isLeaf: Boolean = false, row: Int = 0)
+    final case class CellInfo(isSelected: Boolean = false, isExpanded: Boolean = false,
+                              isLeaf: Boolean = false, row: Int = 0)
     override val emptyCellInfo = CellInfo()
+
     override type Peer = jst.TreeCellEditor
   
     def wrap[A](e: jst.TreeCellEditor): Editor[A] = new Wrapped[A](e)
@@ -24,7 +27,7 @@ sealed trait TreeEditors extends EditableCellsCompanion {
     /**
      * Wrapper for <code>javax.swing.tree.TreeCellEditor<code>s
      */
-    class Wrapped[A](override val peer: jst.TreeCellEditor) extends Editor[A] {
+    final class Wrapped[A](override val peer: jst.TreeCellEditor) extends Editor[A] {
       override def componentFor(tree: Tree[_], a: A, cellInfo: CellInfo): Component = {
         Component.wrap(peer.getTreeCellEditorComponent(tree.peer, a, cellInfo.isSelected, 
             cellInfo.isExpanded, cellInfo.isLeaf, cellInfo.row).asInstanceOf[js.JComponent])
@@ -58,7 +61,7 @@ sealed trait TreeEditors extends EditableCellsCompanion {
         }
         def addCellEditorListener(cel: jse.CellEditorListener) { editor.peer.addCellEditorListener(cel) }
         def cancelCellEditing() { editor.peer.cancelCellEditing() }
-        def getCellEditorValue(): AnyRef = toA(editor.peer.getCellEditorValue.asInstanceOf[B]).asInstanceOf[AnyRef]
+        def getCellEditorValue: AnyRef = toA(editor.peer.getCellEditorValue.asInstanceOf[B]).asInstanceOf[AnyRef]
         def isCellEditable(e: ju.EventObject) = editor.peer.isCellEditable(e)
         def removeCellEditorListener(cel: jse.CellEditorListener) { editor.peer.removeCellEditorListener(cel) }
         def shouldSelectCell(e: ju.EventObject) = { editor.peer.shouldSelectCell(e) }
@@ -90,11 +93,12 @@ sealed trait TreeEditors extends EditableCellsCompanion {
     }
     
     protected class TreeEditorPeer extends EditorPeer with jst.TreeCellEditor {
-      override def getTreeCellEditorComponent(tree: js.JTree, value: Any, selected: Boolean, expanded: Boolean, leaf: Boolean, rowIndex: Int) = {
+      override def getTreeCellEditorComponent(tree: js.JTree, value: Any, selected: Boolean, expanded: Boolean,
+                                              leaf: Boolean, rowIndex: Int) = {
         val treeWrapper = getTreeWrapper(tree)
         val a = treeWrapper.model unpackNode value
-        componentFor(treeWrapper, a, CellInfo(isSelected=selected, 
-            isExpanded=expanded, isLeaf=leaf, row=rowIndex)).peer
+        componentFor(treeWrapper, a,
+          CellInfo(isSelected = selected, isExpanded = expanded, isLeaf = leaf, row = rowIndex)).peer
       }
     }
 
@@ -105,14 +109,14 @@ sealed trait TreeEditors extends EditableCellsCompanion {
 
 
 sealed trait TreeRenderers extends RenderableCellsCompanion {
-  this: Tree.type =>
+  _: Tree.type =>
 
   protected override type Owner = Tree[_]
   
   object Renderer extends CellRendererCompanion {
       
-    case class CellInfo(isSelected: Boolean = false, isExpanded: Boolean = false, 
-            isLeaf: Boolean = false, row: Int = 0, hasFocus: Boolean = false)
+    final case class CellInfo(isSelected: Boolean = false, isExpanded: Boolean = false,
+                              isLeaf: Boolean = false, row: Int = 0, hasFocus: Boolean = false)
     override val emptyCellInfo = CellInfo()
     
     type Peer = jst.TreeCellRenderer
@@ -138,7 +142,7 @@ sealed trait TreeRenderers extends RenderableCellsCompanion {
     
     override def default[A] = new DefaultRenderer[A]
     
-    override def labelled[A](f: A => (js.Icon, String)) = new DefaultRenderer[A] with LabelRenderer[A] {val convert = f}
+    override def labeled[A](f: A => (js.Icon, String)) = new DefaultRenderer[A] with LabelRenderer[A] { val convert = f }
   }
   
   /**
@@ -260,8 +264,8 @@ sealed trait TreeRenderers extends RenderableCellsCompanion {
 
 object Tree extends TreeRenderers with TreeEditors { 
 
-  val Path = IndexedSeq
-  type Path[+A] = IndexedSeq[A]
+  val Path = collection.immutable.IndexedSeq
+  type Path[+A] = collection.immutable.IndexedSeq[A]
   
   /**
   *  The style of lines drawn between tree nodes.
@@ -282,7 +286,7 @@ object Tree extends TreeRenderers with TreeEditors {
     val Single = Value(jst.TreeSelectionModel.SINGLE_TREE_SELECTION)
   }
 
-  private[scalaswingcontrib] trait JTreeMixin[A] { def treeWrapper: Tree[A] }
+  protected trait JTreeMixin[A] { def treeWrapper: Tree[A] }
 }
 
 
@@ -293,12 +297,12 @@ object Tree extends TreeRenderers with TreeEditors {
  * 
  * @see javax.swing.JTree
  */
-class Tree[A](private var treeDataModel: TreeModel[A] = TreeModel.empty[A]) 
-    extends Component 
-    with CellView[A] 
-    with EditableCells[A] 
-    with RenderableCells[A] 
-    with Scrollable.Wrapper { thisTree =>
+class Tree[A](private var treeDataModel: TreeModel[A] = TreeModel.empty[A])
+  extends Component
+  with CellView[A]
+  with EditableCells[A]
+  with RenderableCells[A]
+  with Scrollable.Wrapper { thisTree =>
 
   import Tree._  
 
@@ -346,7 +350,7 @@ class Tree[A](private var treeDataModel: TreeModel[A] = TreeModel.empty[A])
     }
     override def componentFor(tree: Tree[_], a: B, info: Editor.CellInfo): Component = {
       val c = peer.getTreeCellEditorComponent(tree.peer, a, info.isSelected, info.isExpanded, 
-          info.isLeaf, info.row).asInstanceOf[java.awt.Component]
+          info.isLeaf, info.row)
           
       // Unfortunately the underlying editor peer returns a java.awt.Component, not a javax.swing.JComponent.
       // Since there is currently no way to wrap a java.awt.Component in a scala.swing.Component, we need to 
@@ -366,16 +370,16 @@ class Tree[A](private var treeDataModel: TreeModel[A] = TreeModel.empty[A])
   object selection extends CellSelection {
   
     object rows extends SelectionSet(peer.getSelectionRows) {
-      def -=(r: Int) = {peer.removeSelectionRow(r); this}
-      def +=(r: Int) = {peer.addSelectionRow(r); this}
-      def --=(rs: Seq[Int]) = {peer.removeSelectionRows(rs.toArray); this}
-      def ++=(rs: Seq[Int]) = {peer.addSelectionRows(rs.toArray); this}
-      def maxSelection = peer.getMaxSelectionRow
-      def minSelection = peer.getMinSelectionRow
+      def -=(r: Int) = { peer.removeSelectionRow(r); this }
+      def +=(r: Int) = { peer.addSelectionRow(r);    this }
+      def --=(rs: Seq[Int]) = { peer.removeSelectionRows(rs.toArray); this }
+      def ++=(rs: Seq[Int]) = { peer.addSelectionRows(   rs.toArray); this }
+      def maxSelection  = peer.getMaxSelectionRow
+      def minSelection  = peer.getMinSelectionRow
       def leadSelection = peer.getLeadSelectionRow
     }
 
-    object paths extends SelectionSet[Path[A]](peer.getSelectionPaths.map(treePathToPath).toSeq) {
+    object paths extends SelectionSet[Path[A]](peer.getSelectionPaths.map(treePathToPath)(breakOut): Seq[Path[A]]) {
       def -=(p: Path[A]) = { peer.removeSelectionPath(p); this }
       def +=(p: Path[A]) = { peer.addSelectionPath(p); this }
       def --=(ps: Seq[Path[A]]) = { peer.removeSelectionPaths(ps.map(pathToTreePath).toArray); this }
@@ -398,11 +402,13 @@ class Tree[A](private var treeDataModel: TreeModel[A] = TreeModel.empty[A])
     def cellValues: Iterator[A] = paths.iterator.map(_.last)
     
     
-    def mode = Tree.SelectionMode(peer.getSelectionModel.getSelectionMode)
-    def mode_=(m: Tree.SelectionMode.Value) {peer.getSelectionModel.setSelectionMode(m.id)}
-    def selectedNode: A = peer.getLastSelectedPathComponent.asInstanceOf[A]
-    def empty = peer.isSelectionEmpty
-    def count = peer.getSelectionCount
+    def mode             = Tree.SelectionMode(peer.getSelectionModel.getSelectionMode)
+    def mode_=(m: Tree.SelectionMode.Value) { peer.getSelectionModel.setSelectionMode(m.id) }
+    def selectedNode: A  = peer.getLastSelectedPathComponent.asInstanceOf[A]
+    def isEmpty          = peer.isSelectionEmpty
+    def size             = peer.getSelectionCount
+
+    def clear() { peer.clearSelection() }
   }
 
   
@@ -425,9 +431,9 @@ class Tree[A](private var treeDataModel: TreeModel[A] = TreeModel.empty[A])
     }
   }
   
-  def isVisible(path: Path[A]) = peer isVisible path
-  def expandPath(path: Path[A]) {peer expandPath path}
-  def expandRow(row: Int) {peer expandRow row}
+  def isVisible( path: Path[A]) = peer isVisible  path
+  def expandPath(path: Path[A]) { peer expandPath path }
+  def expandRow( row: Int)      { peer expandRow  row  }
 
   /**
    * Expands every row. Will not terminate if the tree is of infinite depth.
@@ -440,12 +446,12 @@ class Tree[A](private var treeDataModel: TreeModel[A] = TreeModel.empty[A])
     }
   } 
   
-  def collapsePath(path: Path[A]) {peer collapsePath path}
-  def collapseRow(row: Int) {peer collapseRow row}
+  def collapsePath(path: Path[A]) { peer collapsePath path }
+  def collapseRow(row: Int)       { peer collapseRow  row  }
 
   def model = treeDataModel
   
-  def model_=(tm: TreeModel[A]) = {
+  def model_=(tm: TreeModel[A]) {
     if (treeDataModel != null)
       treeDataModel.peer.removeTreeModelListener(modelListener)
       
@@ -459,48 +465,54 @@ class Tree[A](private var treeDataModel: TreeModel[A] = TreeModel.empty[A])
   /**
    * Collapses all visible rows.
    */
-  def collapseAll() {rowCount-1 to 0 by -1 foreach collapseRow}
+  def collapseAll() { rowCount-1 to 0 by -1 foreach collapseRow }
   
-  def isExpanded(path: Path[A]) = peer isExpanded path
+  def isExpanded( path: Path[A]) = peer isExpanded  path
   def isCollapsed(path: Path[A]) = peer isCollapsed path
   
-  def isEditing() = peer.isEditing()
+  def isEditing = peer.isEditing
   
-  def editable: Boolean = peer.isEditable
-  def editable_=(b: Boolean) {peer.setEditable(b)}
+  def editable: Boolean      = peer.isEditable
+  def editable_=(b: Boolean) { peer.setEditable(b) }
   
-  def editor: Editor[A] =  Editor.wrap(peer.getCellEditor)
-  def editor_=(r: Tree.Editor[A]) { peer.setCellEditor(r.peer); editable = true }
+  def editor: Editor[A] = Editor.wrap(peer.getCellEditor)
+  def editor_=(r: Tree.Editor[A])   { peer.setCellEditor(r.peer); editable = true }
   
   def renderer: Renderer[A] = Renderer.wrap(peer.getCellRenderer)
-  def renderer_=(r: Tree.Renderer[A]) { peer.setCellRenderer(r.peer) }
+  def renderer_=(r: Tree.Renderer[A])     { peer.setCellRenderer(r.peer) }
   
-  def showsRootHandles = peer.getShowsRootHandles
-  def showsRootHandles_=(b:Boolean) { peer.setShowsRootHandles(b) }
+  def showsRootHandles               = peer.getShowsRootHandles
+  def showsRootHandles_=(b: Boolean) { peer.setShowsRootHandles(b) }
   
   def startEditingAtPath(path: Path[A]) { peer.startEditingAtPath(pathToTreePath(path)) }
 
   def getRowForLocation(x: Int, y: Int): Int = peer.getRowForLocation(x, y)
-  def getRowForPath(path: Path[A]) : Int = peer.getRowForPath(pathToTreePath(path))
-  def getClosestPathForLocation(x: Int, y: Int): Path[A] = peer.getClosestPathForLocation(x, y)
-  def getClosestRowForLocation(x: Int, y: Int): Int = peer.getClosestRowForLocation(x, y)
+  def getRowForPath(path: Path[A]) : Int     = peer.getRowForPath(pathToTreePath(path))
+  def getClosestPathForLocation(x: Int, y: Int): Path[A]  = peer.getClosestPathForLocation(x, y)
+  def getClosestRowForLocation( x: Int, y: Int): Int      = peer.getClosestRowForLocation( x, y)
   
-  def lineStyle = Tree.LineStyle withName peer.getClientProperty("JTree.lineStyle").toString
+  def lineStyle        = Tree.LineStyle withName peer.getClientProperty("JTree.lineStyle").toString
   def lineStyle_=(style: Tree.LineStyle.Value) { peer.putClientProperty("JTree.lineStyle", style.toString) }
 
   
   // Follows the naming convention of ListView.selectIndices()
-  def selectRows(rows: Int*)  { peer.setSelectionRows(rows.toArray) }
-  def selectPaths(paths: Path[A]*) { peer.setSelectionPaths(paths.map(pathToTreePath).toArray) }
+  def selectRows(rows: Int*)                { peer.setSelectionRows(rows.toArray) }
+  def selectPaths(paths: Path[A]*)          { peer.setSelectionPaths(paths.map(pathToTreePath).toArray) }
   def selectInterval(first: Int, last: Int) { peer.setSelectionInterval(first, last) }
   
-  def rowCount = peer.getRowCount
-  def rowHeight = peer.getRowHeight
-  def largeModel = peer.isLargeModel
+  def rowCount    = peer.getRowCount
+  def rowHeight   = peer.getRowHeight
+  def largeModel  = peer.isLargeModel
   def scrollableTracksViewportHeight = peer.getScrollableTracksViewportHeight
-  def expandsSelectedPaths = peer.getExpandsSelectedPaths
+  def expandsSelectedPaths               = peer.getExpandsSelectedPaths
   def expandsSelectedPaths_=(b: Boolean) { peer.setExpandsSelectedPaths(b) }
-  def dragEnabled = peer.getDragEnabled
+  def dragEnabled               = peer.getDragEnabled
   def dragEnabled_=(b: Boolean) { peer.setDragEnabled(b) }
 
+  def visibleRowCount: Int         = peer.getVisibleRowCount
+  def visibleRowCount_=(rows: Int) { peer.setVisibleRowCount(rows) }
+  def makeVisible(path: Path[A])   { peer.makeVisible(pathToTreePath(path)) }
+  def cancelEditing()              { peer.cancelEditing() }
+  def stopEditing(): Boolean     = { peer.stopEditing() }
+  def editingPath                  = peer.getEditingPath
 }

--- a/src/main/scala/scalaswingcontrib/tree/TreeModel.scala
+++ b/src/main/scala/scalaswingcontrib/tree/TreeModel.scala
@@ -2,9 +2,7 @@ package scalaswingcontrib
 package tree
 
 import Tree.Path
-import javax.swing.{event => jse}
 import javax.swing.{tree => jst}
-import scala.sys.error
 
 object TreeModel {
   
@@ -27,7 +25,7 @@ trait TreeModel[A] {
   def getChildPathsOf(parentPath: Path[A]): Seq[Path[A]] = getChildrenOf(parentPath).map(parentPath :+ _)
   def filter(p: A => Boolean): TreeModel[A]
   def map[B](f: A => B): TreeModel[B]
-  def foreach[U](f: A => U): Unit = depthFirstIterator foreach f
+  def foreach[U](f: A => U) { depthFirstIterator foreach f }
   def isExternalModel: Boolean
   def toInternalModel: InternalTreeModel[A]
   
@@ -56,7 +54,7 @@ trait TreeModel[A] {
     
     val parentPath = path.init
     val index = siblingsUnder(parentPath) indexOf path.last
-    insertUnder(parentPath, newValue, index+1)
+    insertUnder(parentPath, newValue, index + 1)
   }
   
   protected def siblingsUnder(parentPath: Path[A]) = if (parentPath.isEmpty) roots 
@@ -73,11 +71,11 @@ trait TreeModel[A] {
     def pushChildren(path: Path[A]): Unit
     def hasNext = openNodes.nonEmpty
     def next() = if (openNodes.hasNext) {
-      val path: Path[A] = openNodes.next
+      val path = openNodes.next()
       pushChildren(path)
       path.last
     }
-    else error("No more items")
+    else throw new NoSuchElementException("No more items")
   }
   
   def breadthFirstIterator: Iterator[A] = new TreeIterator {


### PR DESCRIPTION
merges in changes made in my fork of Ken Scambler's ScalaSwingTreeWrapper.
- adds missing methods to tree, such as visibleRowCount, makeVisible
- corrects some scala style issues (getter methods should not have empty parens)
- some small improvements (case classes are final, unnecessary abstract vals replaced by defs)
- renaming in tree selection: empty -> isEmpty; count -> size (which is more coherent with existing scala collections terminology)
- renamed Renderer.labelled (british english) to .labeled (american english)
- add .idea paths to .gitignore
- bump version to 1.5-SNAPSHOT. update gpg plugin. some small build.sbt improvements
