### PR TITLE
Fixed: dispatchToScalaRenderer incorrectly assuming peer node is a model node

### DIFF
--- a/src/main/scala/scalaswingcontrib/tree/InternalTreeModel.scala
+++ b/src/main/scala/scalaswingcontrib/tree/InternalTreeModel.scala
@@ -115,4 +115,6 @@ class InternalTreeModel[A] private (val peer: PeerModel) extends TreeModel[A] {
   def isExternalModel = false
   
   override def unpackNode(node: Any): A = node.asInstanceOf[PeerNode].getUserObject.asInstanceOf[A]
+
+  override def isRootNode(node: Any): Boolean = node.asInstanceOf[PeerNode].getUserObject == TreeModel.hiddenRoot
 }

--- a/src/main/scala/scalaswingcontrib/tree/Tree.scala
+++ b/src/main/scala/scalaswingcontrib/tree/Tree.scala
@@ -1,8 +1,6 @@
 package scalaswingcontrib
 package tree
 
-import javax.swing.tree.DefaultMutableTreeNode
-
 import scalaswingcontrib.event.{TreeNodesInserted, TreeNodesRemoved, TreeStructureChanged, TreeNodesChanged, TreePathSelected}
 import scala.swing.{Color, Component, Label, Scrollable}
 import java.{util => ju}

--- a/src/main/scala/scalaswingcontrib/tree/Tree.scala
+++ b/src/main/scala/scalaswingcontrib/tree/Tree.scala
@@ -162,15 +162,12 @@ sealed trait TreeRenderers extends RenderableCellsCompanion {
         case _ => throw new IllegalArgumentException(
           "This javax.swing.JTree does not mix in JTreeMixin, and so cannot be used by scala.swing.Tree#Renderer")
       }
-      value match {
-      
-        // JTree's TreeModel property change will indirectly cause the Renderer 
-        // to be activated on the root node, even if it is permanently hidden; since our underlying root node
-        // is not a suitably-typed A, we need to intercept it and return a harmless component.
-        case TreeModel.hiddenRoot => new js.JTextField
-        case _ => 
-          val a = treeWrapper.model unpackNode value
-          componentFor(treeWrapper, a, CellInfo(isSelected=selected, isExpanded=expanded, isLeaf=leaf, row=rowIndex, hasFocus=focus)).peer
+
+      if (treeWrapper.model isRootNode value) {
+        new js.JTextField
+      } else {
+        val a = treeWrapper.model unpackNode value
+        componentFor(treeWrapper, a, CellInfo(isSelected=selected, isExpanded=expanded, isLeaf=leaf, row=rowIndex, hasFocus=focus)).peer
       }
     }
     

--- a/src/main/scala/scalaswingcontrib/tree/TreeModel.scala
+++ b/src/main/scala/scalaswingcontrib/tree/TreeModel.scala
@@ -92,5 +92,7 @@ trait TreeModel[A] {
   def size: Int = depthFirstIterator.size
   
   def unpackNode(node: Any): A = node.asInstanceOf[A]
+
+  def isRootNode(node: Any): Boolean = node == TreeModel.hiddenRoot
 }
 


### PR DESCRIPTION
... causing exception on setModel with InternalTreeModel (fix to #11)