### PR TITLE
Move implemented (copy / paste interface in the demo).

### DIFF
--- a/src/main/scala/scalaswingcontrib/TransferHandlerRow.scala
+++ b/src/main/scala/scalaswingcontrib/TransferHandlerRow.scala
@@ -1,0 +1,176 @@
+package scalaswingcontrib
+
+import java.awt.Cursor
+import java.awt.datatransfer.{Clipboard, Transferable, DataFlavor}
+import java.awt.dnd.DragSource
+import javax.activation.{DataHandler, ActivationDataFlavor}
+import javax.swing.JTable.DropLocation
+import javax.swing._
+
+import scala.reflect.ClassTag
+import scalaswingcontrib.tree.{ExternalTreeModel, Tree}
+
+// adapted from http://stackoverflow.com/a/4769575/16673
+
+trait ClipboardCallbacks {
+  def paste(xf:Transferable) = {}
+  def copy(clip: Clipboard) = {}
+  def cut(clip: Clipboard) = {}
+}
+
+trait Reorderable {
+  def reorder(from: Int, to: Int)
+}
+
+object RowTransferable {
+  val localObjectFlavor = new ActivationDataFlavor(classOf[RowTransferable], DataFlavor.javaJVMLocalObjectMimeType,
+    "Integer Row Index")
+}
+
+import RowTransferable._
+
+private class RowTransferable(val row: Int, val from: JComponent) extends Transferable {
+
+  override def getTransferData(flavor: DataFlavor): AnyRef = if (flavor == localObjectFlavor) this else null
+
+  override def getTransferDataFlavors: Array[DataFlavor] = Array(localObjectFlavor)
+
+  override def isDataFlavorSupported(flavor: DataFlavor): Boolean = flavor == localObjectFlavor
+}
+
+abstract class TransferRowContainer[Table: ClassTag, DropLocation: ClassTag] {
+  def isContainer(c: java.awt.Component): Boolean
+  def container: Table
+  def selectedRow: Int
+  def setCursor(cursor: Cursor)
+
+  def handleDrop(rowFrom: RowTransferable, dl: DropLocation): Boolean
+}
+
+class TransferHandlerRow[Table: ClassTag, DropLocation: ClassTag](
+  private val container: TransferRowContainer[Table, DropLocation], val clipboardCallbacks: ClipboardCallbacks
+) extends TransferHandler {
+
+  protected override def createTransferable(c: JComponent): Transferable = {
+    assert(container.isContainer(c))
+    new DataHandler(new RowTransferable(container.selectedRow, c), localObjectFlavor.getMimeType)
+  }
+
+  override def canImport(info: TransferHandler.TransferSupport): Boolean = {
+    val b = container.isContainer(info.getComponent) && info.isDrop && info.isDataFlavorSupported(localObjectFlavor)
+    container.setCursor(if (b) DragSource.DefaultMoveDrop else DragSource.DefaultMoveNoDrop)
+    b
+  }
+
+  override def getSourceActions(c: JComponent): Int = TransferHandler.COPY_OR_MOVE
+
+  override def importData(info: TransferHandler.TransferSupport): Boolean = {
+    if (true) {
+      if (info.isDrop) {
+        val dl = info.getDropLocation.asInstanceOf[DropLocation]
+        container.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR))
+        try {
+          val rowFrom = info.getTransferable.getTransferData(localObjectFlavor).asInstanceOf[RowTransferable]
+          // may return null when dropping from a different JVM (application instance)
+          container.handleDrop(rowFrom, dl)
+        } catch {
+          case e: Exception =>
+            e.printStackTrace()
+            false
+        }
+      } else {
+        clipboardCallbacks.paste(info.getTransferable)
+        true
+      }
+    } else {
+      true
+    }
+  }
+
+  override def exportToClipboard(comp: JComponent, clip: Clipboard, action: Int): Unit = {
+    // action == TransferHandler.MOVE means cut, TransferHandler.MOVE means copy
+    exportDone(comp, null, TransferHandler.NONE)
+  }
+
+  protected override def exportDone(c: JComponent, t: Transferable, act: Int) {
+    act match {
+      case TransferHandler.MOVE =>
+        container.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR))
+      case TransferHandler.NONE =>
+        container.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR))
+    }
+  }
+}
+
+
+class TransferRowContainerTable(override val container: JTable) extends TransferRowContainer[JTable, JTable.DropLocation] {
+  private def dropRow(dl: DropLocation) = dl.getRow
+  private def rowCount = container.getRowCount
+  private def select(index: Int) = container.getSelectionModel.setSelectionInterval(index, index)
+  private def reorder(from: Int, to: Int) = container.getModel.asInstanceOf[Reorderable].reorder(from, to)
+
+
+  override def isContainer(c: java.awt.Component): Boolean = container == c
+  override def selectedRow = container.getSelectedRow
+  override def setCursor(cursor: Cursor) = container.setCursor(cursor)
+
+  override def handleDrop(rowFrom: RowTransferable, dl: DropLocation) = {
+    var index = dropRow(dl)
+    val max = rowCount
+    if (index < 0 || index > max) index = max
+    if (rowFrom != null && rowFrom.from == container && rowFrom.row != -1 && rowFrom.row != index) {
+      reorder(rowFrom.row, index)
+      if (index > rowFrom.row) index -= 1
+      select(index)
+      true
+    }
+    else false
+  }
+}
+
+class TableTransferHandlerRow(table: JTable, clipboardCallbacks: ClipboardCallbacks)
+  extends TransferHandlerRow[JTable, JTable.DropLocation](new TransferRowContainerTable(table), clipboardCallbacks)
+
+
+class TransferRowContainerTree[A](override val container: Tree[A]) extends TransferRowContainer[Tree[A], JTree.DropLocation] {
+  private def tree =  container
+  override def isContainer(c: java.awt.Component): Boolean = container.peer == c
+  override def selectedRow = container.peer.getLeadSelectionRow
+  override def setCursor(cursor: Cursor) = container.peer.setCursor(cursor)
+  override def handleDrop(rowFrom: RowTransferable, dl: JTree.DropLocation): Boolean = {
+    // import container._ // shorter code, but perhaps dangerous conversions?
+    val pathFrom = tree.treePathToPath(tree.peer.getPathForRow(rowFrom.row))
+    val pathTo = tree.treePathToPath(dl.getPath)
+    val inserted = if (dl.getChildIndex >= 0) {
+      // DropMode.ON - path is the node
+      tree.model.insertUnder(pathTo, pathFrom.last, dl.getChildIndex)
+    } else {
+      //DropMode.INSERT
+      tree.model.insertUnder(pathTo, pathFrom.last, tree.model.getChildrenOf(pathTo).size)
+    }
+    // insert failed can mean a move was performed (node not found after move)
+    // beware: at this point the tree contains the same node twice
+    if (inserted) {
+      tree.model.remove(pathFrom)
+      // TODO: is delete failure possible? Should we handle it?
+    }
+    // TODO: use move interface instead once available
+    tree.model match {
+      case ext: ExternalTreeModel[A] =>
+        if (pathFrom.startsWith(pathTo) || pathTo.startsWith(pathFrom)) {
+          // fire structure change, insertion has performed a move
+          // fire for the shorter, but update the whole subtree
+          val prefix = (pathFrom zip pathTo).map(_._1)
+          ext.peer.fireTreeStructureChanged(ext.pathToTreePath(prefix.dropRight(1)), null)
+        } else {
+          // independent changes, fire them both
+          //ext.peer.fireTreeStructureChanged(ext.pathToTreePath(pathTo), null)
+          //ext.peer.fireTreeStructureChanged(ext.pathToTreePath(pathFrom), null)
+        }
+    }
+    true
+  }
+}
+
+class TreeTransferHandlerRow[A](tree: Tree[A], clipboardCallbacks: ClipboardCallbacks)
+  extends TransferHandlerRow[Tree[A], JTree.DropLocation](new TransferRowContainerTree(tree), clipboardCallbacks)

--- a/src/main/scala/scalaswingcontrib/TransferHandlerRow.scala
+++ b/src/main/scala/scalaswingcontrib/TransferHandlerRow.scala
@@ -8,7 +8,7 @@ import javax.swing.JTable.DropLocation
 import javax.swing._
 
 import scala.reflect.ClassTag
-import scalaswingcontrib.tree.{ExternalTreeModel, Tree}
+import scalaswingcontrib.tree.Tree
 
 // adapted from http://stackoverflow.com/a/4769575/16673
 
@@ -141,34 +141,13 @@ class TransferRowContainerTree[A](override val container: Tree[A]) extends Trans
     // import container._ // shorter code, but perhaps dangerous conversions?
     val pathFrom = tree.treePathToPath(tree.peer.getPathForRow(rowFrom.row))
     val pathTo = tree.treePathToPath(dl.getPath)
-    val inserted = if (dl.getChildIndex >= 0) {
+    if (dl.getChildIndex >= 0) {
       // DropMode.ON - path is the node
-      tree.model.insertUnder(pathTo, pathFrom.last, dl.getChildIndex)
+      tree.model.move(pathFrom, pathTo, dl.getChildIndex)
     } else {
       //DropMode.INSERT
-      tree.model.insertUnder(pathTo, pathFrom.last, tree.model.getChildrenOf(pathTo).size)
+      tree.model.move(pathFrom, pathTo, tree.model.getChildrenOf(pathTo).size)
     }
-    // insert failed can mean a move was performed (node not found after move)
-    // beware: at this point the tree contains the same node twice
-    if (inserted) {
-      tree.model.remove(pathFrom)
-      // TODO: is delete failure possible? Should we handle it?
-    }
-    // TODO: use move interface instead once available
-    tree.model match {
-      case ext: ExternalTreeModel[A] =>
-        if (pathFrom.startsWith(pathTo) || pathTo.startsWith(pathFrom)) {
-          // fire structure change, insertion has performed a move
-          // fire for the shorter, but update the whole subtree
-          val prefix = (pathFrom zip pathTo).map(_._1)
-          ext.peer.fireTreeStructureChanged(ext.pathToTreePath(prefix.dropRight(1)), null)
-        } else {
-          // independent changes, fire them both
-          //ext.peer.fireTreeStructureChanged(ext.pathToTreePath(pathTo), null)
-          //ext.peer.fireTreeStructureChanged(ext.pathToTreePath(pathFrom), null)
-        }
-    }
-    true
   }
 }
 

--- a/src/main/scala/scalaswingcontrib/test/TreeDemo.scala
+++ b/src/main/scala/scalaswingcontrib/test/TreeDemo.scala
@@ -97,7 +97,8 @@ object TreeDemo extends SimpleSwingApplication {
         if (parentPath.isEmpty) false
         else {
           val parentDir = parentPath.last
-          if (parentDir.children contains fileToInsert) false
+          if (parentPath contains fileToInsert) false
+          else if (parentDir.children contains fileToInsert) false
           else parentDir.insertChild(fileToInsert.copy(), index)
         }
       

--- a/src/main/scala/scalaswingcontrib/test/TreeDemo.scala
+++ b/src/main/scala/scalaswingcontrib/test/TreeDemo.scala
@@ -310,8 +310,12 @@ object TreeDemo extends SimpleSwingApplication {
       def rename(str: String): Boolean = if (siblingExists(str)) false 
                                          else { nameVar = str; true }
 
-      def copy() = {
-        PretendFile(nameVar, childBuffer: _*)
+      def copy(): PretendFile = {
+        // no need to copy children, this is in fact a move, not a copy
+        val ret = PretendFile(nameVar, childBuffer: _*)
+        // but we need to notify them about a new parent
+        ret.childBuffer foreach (_.parent = Some(ret))
+        ret
       }
       def insertChild(child: PretendFile, index: Int): Boolean = {
         if (!isDirectory) false

--- a/src/main/scala/scalaswingcontrib/tree/ExternalTreeModel.scala
+++ b/src/main/scala/scalaswingcontrib/tree/ExternalTreeModel.scala
@@ -193,7 +193,8 @@ class ExternalTreeModel[A: ClassTag](rootItems: collection.Seq[A], children: A =
     if (pathFrom.isEmpty || pathTo.isEmpty) return false
 
     val parentPath = pathFrom.init
-    val index = siblingsUnder(parentPath) indexOf pathFrom.last
+    val under = siblingsUnder(parentPath)
+    val index = under indexOf pathFrom.last
     if (index == -1) return false
 
     val succeeded = moveFunc(pathFrom, pathTo, indexTo)

--- a/src/main/scala/scalaswingcontrib/tree/ExternalTreeModel.scala
+++ b/src/main/scala/scalaswingcontrib/tree/ExternalTreeModel.scala
@@ -59,7 +59,7 @@ class ExternalTreeModel[A: ClassTag](rootItems: collection.Seq[A], children: A =
   /** 
    * A function to insert a value in the model at a given path, returning whether the operation succeeded.  
    * By default this will throw an exception; to allow insertion on a TreeModel, 
-   * call insertableWith() to provide a new TreeModel with the specified insert method.
+   * call makeInsertableWith() to provide a new TreeModel with the specified insert method.
    */
   protected[tree] val insertFunc: (Path[A], A, Int) => Boolean = {
     (_,_,_) => throw new UnsupportedOperationException("Insert is not supported on this tree")
@@ -68,12 +68,22 @@ class ExternalTreeModel[A: ClassTag](rootItems: collection.Seq[A], children: A =
   /** 
    * A function to remove a item in the model at a given path, returning whether the operation succeeded.  
    * By default this will throw an exception; to allow removal from a TreeModel, 
-   * call removableWith() to provide a new TreeModel with the specified remove method.
+   * call makeRemovableWith() to provide a new TreeModel with the specified remove method.
    */
   protected[tree] val removeFunc: Path[A] => Boolean = {
     _ => throw new UnsupportedOperationException("Removal is not supported on this tree")
   }
-  
+
+  /**
+    * A function to move a value in the model from a given path to at a given path, returning whether the operation
+    * succeeded.
+    * By default this will throw an exception; to allow insertion on a TreeModel,
+    * call makeInsertableWith() to provide a new TreeModel with the specified insert method.
+    */
+  protected[tree] val moveFunc: (Path[A], Path[A], Int) => Boolean = {
+    (_,_,_) => throw new UnsupportedOperationException("Move is not supported on this tree")
+  }
+
   /**
    * Returns a new VirtualTreeModel that knows how to modify the underlying representation, 
    * using the given function to replace one value with another.   
@@ -84,6 +94,7 @@ class ExternalTreeModel[A: ClassTag](rootItems: collection.Seq[A], children: A =
     override val updateFunc = effectfulUpdate
     override val insertFunc = self.insertFunc
     override val removeFunc = self.removeFunc
+    override val moveFunc = self.moveFunc
     this.peer copyListenersFrom self.peer
   }
 
@@ -91,6 +102,7 @@ class ExternalTreeModel[A: ClassTag](rootItems: collection.Seq[A], children: A =
     override val updateFunc = self.updateFunc
     override val insertFunc = effectfulInsert
     override val removeFunc = self.removeFunc
+    override val moveFunc = self.moveFunc
     this.peer copyListenersFrom self.peer
   }
   
@@ -98,9 +110,18 @@ class ExternalTreeModel[A: ClassTag](rootItems: collection.Seq[A], children: A =
     override val updateFunc = self.updateFunc
     override val insertFunc = self.insertFunc
     override val removeFunc = effectfulRemove
+    override val moveFunc = self.moveFunc
     this.peer copyListenersFrom self.peer
   }
-  
+
+  def makeMovableWith(effectfulMove: (Path[A], Path[A], Int) => Boolean): ExternalTreeModel[A] = new ExternalTreeModel(roots, children) {
+    override val updateFunc = self.updateFunc
+    override val insertFunc = self.insertFunc
+    override val removeFunc = self.removeFunc
+    override val moveFunc = effectfulMove
+    this.peer copyListenersFrom self.peer
+  }
+
   /**
    * Replaces one value with another, mutating the underlying structure.  
    * If a way to modify the external tree structure has not been provided with makeUpdatableWith(), then
@@ -165,6 +186,32 @@ class ExternalTreeModel[A: ClassTag](rootItems: collection.Seq[A], children: A =
 
       peer.fireNodesRemoved(pathToTreePath(parentPath), pathToRemove.last, index)
     }
+    succeeded
+  }
+
+  def move(pathFrom: Path[A], pathTo: Path[A], indexTo: Int): Boolean = {
+    if (pathFrom.isEmpty || pathTo.isEmpty) return false
+
+    val parentPath = pathFrom.init
+    val index = siblingsUnder(parentPath) indexOf pathFrom.last
+    if (index == -1) return false
+
+    val succeeded = moveFunc(pathFrom, pathTo, indexTo)
+    if (succeeded) {
+
+      if (pathTo.isEmpty) {
+        val (before, after) = rootsVar splitAt index
+        rootsVar = before ::: pathFrom.last :: after
+      }
+
+      val actualIndex = siblingsUnder(pathTo) indexOf pathFrom.last
+      if (actualIndex == -1) return false
+
+      // we could also consider find a common path and firing peer.fireTreeStructureChanged instead
+      peer.fireNodesRemoved(pathToTreePath(parentPath), pathFrom.last, index)
+      peer.fireNodesInserted(pathToTreePath(pathTo), pathFrom.last, actualIndex)
+    }
+
     succeeded
   }
 

--- a/src/main/scala/scalaswingcontrib/tree/InternalTreeModel.scala
+++ b/src/main/scala/scalaswingcontrib/tree/InternalTreeModel.scala
@@ -76,6 +76,14 @@ class InternalTreeModel[A: ClassTag] private (val peer: PeerModel) extends TreeM
     peer.removeNodeFromParent(getPeerNodeAt(pathToRemove))
     true
   }
+
+  def move(pathFrom: Path[A], pathTo: Path[A], indexTo: Int): Boolean = {
+    val node = getPeerNodeAt(pathFrom)
+    peer.removeNodeFromParent(node)
+    peer.insertNodeInto(node, getPeerNodeAt(pathTo), indexTo)
+    true
+  }
+
   
   def map[B: ClassTag](f: A => B): InternalTreeModel[B] = new InternalTreeModel[B] {
     override val peer = copyFromModel(self, f)

--- a/src/main/scala/scalaswingcontrib/tree/TreeModel.scala
+++ b/src/main/scala/scalaswingcontrib/tree/TreeModel.scala
@@ -42,6 +42,7 @@ trait TreeModel[A] {
   def update(path: Path[A], newValue: A): Unit
   def remove(pathToRemove: Path[A]): Boolean
   def insertUnder(parentPath: Path[A], newValue: A, index: Int): Boolean
+  def move(pathFrom: Path[A], pathTo: Path[A], indexTo: Int): Boolean
   
   def insertBefore(path: Path[A], newValue: A): Boolean = {
     if (path.isEmpty) throw new IllegalArgumentException("Cannot insert before empty path")


### PR DESCRIPTION
Implemented a move in the tree model. While move can be replaced with delete / insert, this has some serious drawbacks:
- it is hard to validate the move (and to prevent it when the move should not be done)
- it is hard to handle failures (second operation can fail, while the first has already completed)

This pull request adds move into the TreeModel interface, it implements move in the internal tree model and provides a demo implementation for both internal and external model demos (using Cut / Paste interface).
