### PR TITLE
Version 1.8 - updated for 2.13, removed support for 2.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,43 +2,45 @@ name := "ScalaSwingContrib"
 
 organization := "com.github.benhutchison"
 
-version := "1.7"
+version := "1.8"
 
-scalaVersion := "2.12.0"
+scalaVersion := "2.13.1"
 
 sonatypeProfileName := "com.github.benhutchison"
 
-libraryDependencies ++= {
-  val sv = scalaVersion.value
-  if (sv startsWith "2.10")
-    Seq("org.scala-lang" % "scala-swing" % sv)
-  else
-    Seq(
-      "org.scala-lang.modules" %% "scala-swing" % "2.0.0-M2",
-      "org.scala-lang.modules" %% "scala-xml" % "1.0.5"
-    )
-}
-
 libraryDependencies ++= Seq(
-  "org.specs2" %% "specs2-core" % "3.8.6" % "test",
-  "org.specs2" %% "specs2-junit" % "3.8.6" % "test",
+  "org.scala-lang.modules" %% "scala-swing" % "2.1.1",
+  "org.scala-lang.modules" %% "scala-xml" % "1.2.0",
+
+  "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.2",
+
+  "org.specs2" %% "specs2-core" % "4.8.3" % "test",
+  "org.specs2" %% "specs2-junit" % "4.8.3" % "test",
+
   "junit" % "junit" % "4.7" % "test"
 )
 
 scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature")
 
-crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.0")
+crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1")
+
+unmanagedSourceDirectories in Compile += {
+  val sourceDir = (sourceDirectory in Compile).value
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, n)) if n >= 13 => sourceDir / "scala-2.13+"
+    case _                       => sourceDir / "scala-2.13-"
+  }
+}
 
 // Following settings taken from: 
 //https://github.com/sbt/sbt.github.com/blob/gen-master/src/jekyll/using_sonatype.md
 
 publishMavenStyle := true
 
-
-publishTo <<= version { (v: String) =>
+publishTo := {
   val nexus = "https://oss.sonatype.org/"
-  if (v.trim.endsWith("SNAPSHOT")) 
-    Some("snapshots" at nexus + "content/repositories/snapshots") 
+  if (isSnapshot.value)
+    Some("snapshots" at nexus + "content/repositories/snapshots")
   else
     Some("releases"  at nexus + "service/local/staging/deploy/maven2")
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")

--- a/src/main/scala-2.13+/scalaswingcontrib/MutableSet.scala
+++ b/src/main/scala-2.13+/scalaswingcontrib/MutableSet.scala
@@ -1,0 +1,8 @@
+package scalaswingcontrib
+
+import scala.collection.mutable
+
+trait MutableSet[A] extends mutable.Set[A] {
+  override def clear() = throw new NotImplementedError // required by 2.13, but we are not using it
+
+}

--- a/src/main/scala-2.13-/scalaswingcontrib/MutableSet.scala
+++ b/src/main/scala-2.13-/scalaswingcontrib/MutableSet.scala
@@ -1,0 +1,12 @@
+package scalaswingcontrib
+
+import scala.collection.mutable
+
+trait MutableSet[S] extends mutable.Set[S] {
+  // use 2.13 style interface to define 2.12 collections
+  def subtractOne(s: S): this.type
+  def addOne(s: S): this.type
+
+  final def -=(s: S): this.type = subtractOne(s)
+  final def +=(s: S): this.type = addOne(s)
+}

--- a/src/main/scala/scalaswingcontrib/AbsoluteLayoutPanel.scala
+++ b/src/main/scala/scalaswingcontrib/AbsoluteLayoutPanel.scala
@@ -23,13 +23,13 @@ class AbsoluteLayoutPanel(val adjustForBorder: Boolean) extends Panel with Conta
   
   protected def areValid(c: Constraints) = (true, "")
   
-  protected def add(comp: Component, c: Constraints) {
+  protected def add(comp: Component, c: Constraints): Unit = {
     val xInset = if (adjustForBorder) insets.left else 0 
     val yInset = if (adjustForBorder) insets.top else 0 
     
     def adjusted(c: Constraints) = (c._1 + xInset, c._2 + yInset)
     
-    def largestChildSize: (Int, Int) = ((0,0) /: contents) {(size, next) => 
+    def largestChildSize: (Int, Int) = contents.foldLeft((0,0)) {(size, next) =>
       import math.max
       (max(size._1, next.location.x - xInset + next.size.width), 
        max(size._2, next.location.y - yInset + next.size.height))

--- a/src/main/scala/scalaswingcontrib/CellView.scala
+++ b/src/main/scala/scalaswingcontrib/CellView.scala
@@ -24,15 +24,15 @@ trait CellView[+A] {
     * Allows querying and modification of the current selection state, for some unique coordinate S.
     * There may be more than one selection set supporting different coordinates, such as rows and columns.
     */
-    protected abstract class SelectionSet[S](a: => Seq[S]) extends mutable.Set[S] { 
-      def -=(s: S): this.type 
-      def +=(s: S): this.type
-      def --=(ss: Seq[S]): this.type 
-      def ++=(ss: Seq[S]): this.type
+    protected abstract class SelectionSet[S](a: => collection.Seq[S]) extends MutableSet[S] {
+      def subtractOne(s: S): this.type
+      def addOne(s: S): this.type
+      def --=(ss: collection.Seq[S]): this.type
+      def ++=(ss: collection.Seq[S]): this.type
       override def size = nonNullOrEmpty(a).length
       def contains(s: S) = nonNullOrEmpty(a) contains s
       def iterator = nonNullOrEmpty(a).iterator
-      protected def nonNullOrEmpty[A1](s: Seq[A1]) = if (s != null) s else Seq.empty
+      protected def nonNullOrEmpty[A1](s: collection.Seq[A1]) = if (s != null) s else Seq.empty
     }
     
     /**

--- a/src/main/scala/scalaswingcontrib/ColorChooser.scala
+++ b/src/main/scala/scalaswingcontrib/ColorChooser.scala
@@ -26,7 +26,7 @@ class ColorChooser(initialColor: Color) extends Component {
   override lazy val peer: js.JColorChooser =  new js.JColorChooser(initialColor) with SuperMixin
 
   peer.getSelectionModel().addChangeListener(new jse.ChangeListener {
-    def stateChanged(e: jse.ChangeEvent) { 
+    def stateChanged(e: jse.ChangeEvent): Unit = {
       publish( new ColorChangeEvent(peer.getColor)) 
     }
   })

--- a/src/main/scala/scalaswingcontrib/EditableCellsCompanion.scala
+++ b/src/main/scala/scalaswingcontrib/EditableCellsCompanion.scala
@@ -29,13 +29,13 @@ trait EditableCellsCompanion {
     val companion: CellEditorCompanion
     def peer: companion.Peer
 
-    protected def fireCellEditingCancelled() { publish(CellEditingCancelled(CellEditor.this)) }
-    protected def fireCellEditingStopped()   { publish(CellEditingStopped(  CellEditor.this)) }
+    protected def fireCellEditingCancelled(): Unit = { publish(CellEditingCancelled(CellEditor.this)) }
+    protected def fireCellEditingStopped(): Unit = { publish(CellEditingStopped(  CellEditor.this)) }
 
-    protected def listenToPeer(p: js.CellEditor) {
+    protected def listenToPeer(p: js.CellEditor): Unit = {
       p.addCellEditorListener(new jse.CellEditorListener {
-        override def editingCanceled(e: jse.ChangeEvent) { fireCellEditingCancelled() }
-        override def editingStopped(e: jse.ChangeEvent) { fireCellEditingStopped() }
+        override def editingCanceled(e: jse.ChangeEvent): Unit = { fireCellEditingCancelled() }
+        override def editingStopped(e: jse.ChangeEvent): Unit = { fireCellEditingStopped() }
       })
     }
 
@@ -48,7 +48,7 @@ trait EditableCellsCompanion {
     
     def cellEditable        = peer.isCellEditable(null)
     def shouldSelectCell    = peer.shouldSelectCell(null)
-    def cancelCellEditing() { peer.cancelCellEditing() }
+    def cancelCellEditing(): Unit = { peer.cancelCellEditing() }
     def stopCellEditing()   = peer.stopCellEditing
   }
 }

--- a/src/main/scala/scalaswingcontrib/PopupMenu.scala
+++ b/src/main/scala/scalaswingcontrib/PopupMenu.scala
@@ -38,16 +38,16 @@ class PopupMenu extends Component with SequentialContainer.Wrapper {
     def popupMenuWrapper = PopupMenu.this
   }
 
-  def show(invoker: Component, x: Int, y: Int) {peer.show(invoker.peer, x, y)}
+  def show(invoker: Component, x: Int, y: Int): Unit = {peer.show(invoker.peer, x, y)}
 
-  def showWithCallback(invoker: Component, x: Int, y: Int, onHide: () => Unit) {
+  def showWithCallback(invoker: Component, x: Int, y: Int, onHide: () => Unit): Unit = {
     val listener = new js.event.PopupMenuListener {
-      def popupMenuWillBecomeVisible(e: js.event.PopupMenuEvent) {}
-      def popupMenuWillBecomeInvisible(e: js.event.PopupMenuEvent) {
+      def popupMenuWillBecomeVisible(e: js.event.PopupMenuEvent): Unit = {}
+      def popupMenuWillBecomeInvisible(e: js.event.PopupMenuEvent): Unit = {
         onHide()
         peer.removePopupMenuListener(this)
       }
-      def popupMenuCanceled(e: js.event.PopupMenuEvent) {}
+      def popupMenuCanceled(e: js.event.PopupMenuEvent): Unit = {}
     }
 
     peer.addPopupMenuListener(listener)

--- a/src/main/scala/scalaswingcontrib/RichColor.scala
+++ b/src/main/scala/scalaswingcontrib/RichColor.scala
@@ -6,7 +6,7 @@ import Utils._
 
 class RichColor(color: Color) {
 
-  def toHexString = "#" + Integer.toHexString(color.getRGB()).substring(2)
+  def toHexString = "#" + Integer.toHexString(color.getRGB).substring(2)
 
   def *(scale: Int) = mapRgbComponents(_ * scale)
 
@@ -56,15 +56,15 @@ class RichColor(color: Color) {
   
 
   def mapRgbComponents(f: (Int)=>Int) = {
-    val f2 = f.andThen(clamp _)
-    new Color(f2(color.getRed()), f2(color.getGreen()), f2(color.getBlue()))
+    val f2 = f.andThen(clamp)
+    new Color(f2(color.getRed), f2(color.getGreen), f2(color.getBlue))
   }
 
-  def rgbComponents = Seq(color.getRed(), color.getGreen(), color.getBlue())
+  def rgbComponents = Seq(color.getRed, color.getGreen, color.getBlue)
 
   private def clamp(i: Int) = (0 max i) min 255
 
-  private def ensureZeroToOne(value: Double) {assert(value >= 0 && value <= 1.0)}
+  private def ensureZeroToOne(value: Double): Unit = {assert(value >= 0 && value <= 1.0)}
 
   def toRichString = "RichColor(R: "+color.getRed+", G: "+color.getGreen+", B: "+color.getBlue+"/H: "+hue+", S: "+saturation+", B: "+brightness+")"
 }

--- a/src/main/scala/scalaswingcontrib/Utils.scala
+++ b/src/main/scala/scalaswingcontrib/Utils.scala
@@ -3,5 +3,5 @@ package scalaswingcontrib
 /** Put shared util functions here if they don't have any more appropriate place to go.*/
 object Utils {
 
-  def ensurePercent(percent: Int) {require(percent >= -100 && percent <= 100)}
+  def ensurePercent(percent: Int): Unit = {require(percent >= -100 && percent <= 100)}
 }

--- a/src/main/scala/scalaswingcontrib/test/TreeDemo.scala
+++ b/src/main/scala/scalaswingcontrib/test/TreeDemo.scala
@@ -52,11 +52,11 @@ object TreeDemo extends SimpleSwingApplication {
     } 
 
     renderer = Renderer({
-      case Order(id, _, _, 1) => "Order #" + id
-      case Order(id, _, _, qty) => "Order #" + id + " x " + qty
+      case Order(id, _, _, 1) => "Order #" + id.toString
+      case Order(id, _, _, qty) => "Order #" + id.toString + " x " + qty.toString
       case Product(id, _, _) => "Product " + id
       case Customer(_, title, first, last) => title + " " + first + " " + last
-      case (field, value) => field + ": " + value
+      case (field, value) => field.toString + ": " + value.toString
       case x => x.toString
     })
 
@@ -289,7 +289,7 @@ object TreeDemo extends SimpleSwingApplication {
                                                      
       def siblingExists(siblingName: String) = parent.exists(_ childExists siblingName)
       def childExists(childName: String) = children.exists(_.name == childName)
-      def children: Seq[PretendFile] = childBuffer
+      def children: collection.Seq[PretendFile] = childBuffer
       def isDirectory = children.nonEmpty
     }
     

--- a/src/main/scala/scalaswingcontrib/tree/TreeModel.scala
+++ b/src/main/scala/scalaswingcontrib/tree/TreeModel.scala
@@ -4,6 +4,8 @@ package tree
 import Tree.Path
 import javax.swing.{tree => jst}
 
+import scala.reflect.ClassTag
+
 object TreeModel {
   
   /**
@@ -12,20 +14,20 @@ object TreeModel {
    */
   private[tree] case object hiddenRoot
   
-  def empty[A]: TreeModel[A] = new ExternalTreeModel[A](Seq.empty, _ => Seq.empty)
-  def apply[A](roots: A*)(children: A => Seq[A]): TreeModel[A] = new ExternalTreeModel(roots, children)
+  def empty[A: ClassTag]: TreeModel[A] = new ExternalTreeModel[A](Seq.empty, _ => Seq.empty)
+  def apply[A: ClassTag](roots: A*)(children: A => Seq[A]): TreeModel[A] = new ExternalTreeModel(roots, children)
 }
 
 
 trait TreeModel[A] {
   
-  def roots: Seq[A]
+  def roots: collection.Seq[A]
   val peer: jst.TreeModel 
-  def getChildrenOf(parentPath: Path[A]): Seq[A]
-  def getChildPathsOf(parentPath: Path[A]): Seq[Path[A]] = getChildrenOf(parentPath).map(parentPath :+ _)
+  def getChildrenOf(parentPath: Path[A]): collection.Seq[A]
+  def getChildPathsOf(parentPath: Path[A]): collection.Seq[Path[A]] = getChildrenOf(parentPath).map(parentPath :+ _)
   def filter(p: A => Boolean): TreeModel[A]
-  def map[B](f: A => B): TreeModel[B]
-  def foreach[U](f: A => U) { depthFirstIterator foreach f }
+  def map[B: ClassTag](f: A => B): TreeModel[B]
+  def foreach[U](f: A => U): Unit = { depthFirstIterator foreach f }
   def isExternalModel: Boolean
   def toInternalModel: InternalTreeModel[A]
   
@@ -79,11 +81,11 @@ trait TreeModel[A] {
   }
   
   def breadthFirstIterator: Iterator[A] = new TreeIterator {
-    override def pushChildren(path: Path[A]) { openNodes ++= getChildPathsOf(path).toIterator }
+    override def pushChildren(path: Path[A]): Unit = { openNodes ++= getChildPathsOf(path).toIterator }
   }
   
   def depthFirstIterator: Iterator[A] = new TreeIterator {
-    override def pushChildren(path: Path[A]) {
+    override def pushChildren(path: Path[A]): Unit = {
       val open = openNodes
       openNodes = getChildPathsOf(path).toIterator ++ open // ++'s argument is by-name, and should not directly pass in a var
     }


### PR DESCRIPTION
I have updated the source to compile under Scala 2.13. I have fixed most deprecation warnings for 2.13, but there are still a few - fixing them would make the source not compilable with 2.12.

I had to remove support for 2.10 in the process, therefore as of now 2.11, 2.12 and 2.13 are supported.