### PR TITLE
Scala 3 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,34 +1,37 @@
+import scala.math.Ordering.Implicits._
+
 name := "ScalaSwingContrib"
 
 organization := "com.github.benhutchison"
 
-version := "1.8"
+version := "1.9"
 
-scalaVersion := "2.13.1"
+scalaVersion := "3.1.2"
 
 sonatypeProfileName := "com.github.benhutchison"
 
 libraryDependencies ++= Seq(
-  "org.scala-lang.modules" %% "scala-swing" % "2.1.1",
-  "org.scala-lang.modules" %% "scala-xml" % "1.2.0",
+  "org.scala-lang.modules" %% "scala-swing" % "3.0.0",
+  "org.scala-lang.modules" %% "scala-xml" % "2.1.0",
 
-  "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.2",
+  "org.scala-lang.modules" %% "scala-collection-compat" % "2.7.0",
 
-  "org.specs2" %% "specs2-core" % "4.8.3" % "test",
-  "org.specs2" %% "specs2-junit" % "4.8.3" % "test",
+  "org.specs2" %% "specs2-core" % "4.15.0" % Test,
+  "org.specs2" %% "specs2-junit" % "4.15.0" % Test,
 
-  "junit" % "junit" % "4.7" % "test"
+  "junit" % "junit" % "4.7" % Test
 )
 
 scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature")
 
-crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1")
+crossScalaVersions := Seq("2.12.15", "2.13.8", "3.1.2")
 
-unmanagedSourceDirectories in Compile += {
-  val sourceDir = (sourceDirectory in Compile).value
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, n)) if n >= 13 => sourceDir / "scala-2.13+"
-    case _                       => sourceDir / "scala-2.13-"
+Compile / unmanagedSourceDirectories += {
+  val sourceDir = (Compile / sourceDirectory).value
+  if (CrossVersion.partialVersion(scalaVersion.value).exists(_ >= (2, 13))) {
+    sourceDir / "scala-2.13+"
+  } else {
+    sourceDir / "scala-2.13-"
   }
 }
 
@@ -48,11 +51,11 @@ publishTo := {
 //for local testing
 //publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository")))
 
-publishArtifact in Test := false
+Test / publishArtifact := false
 
 pomIncludeRepository := { _ => false }
 
-pomExtra in Global := (
+Global / pomExtra := (
   <url>http://github.com/benhutchison/ScalaSwingContrib</url>
   <licenses>
     <license>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.7
+sbt.version=1.6.2

--- a/src/main/scala/scalaswingcontrib/CellView.scala
+++ b/src/main/scala/scalaswingcontrib/CellView.scala
@@ -58,7 +58,7 @@ trait CellView[+A] {
 * This should be mixed in to CellView implementations that support pluggable renderers.
 */
 trait RenderableCells[A] {
-  _: CellView[A] =>
+  this: CellView[A] with swing.Component =>
   val companion: RenderableCellsCompanion
   def renderer: companion.Renderer[A]
   def renderer_=(r: companion.Renderer[A]): Unit
@@ -68,7 +68,7 @@ trait RenderableCells[A] {
 * This should be mixed in to CellView implementations that support pluggable editors.
 */
 trait EditableCells[A]  {
-  _: CellView[A] =>
+  self: CellView[A] with swing.Component =>
   val companion: EditableCellsCompanion
   def editor: companion.Editor[A]
   def editor_=(r: companion.Editor[A]): Unit

--- a/src/main/scala/scalaswingcontrib/RichColor.scala
+++ b/src/main/scala/scalaswingcontrib/RichColor.scala
@@ -70,7 +70,7 @@ class RichColor(color: Color) {
 }
 object RichColor {
 
-  implicit def color2RichColor(c: Color) = new RichColor(c)
+  implicit def color2RichColor(c: Color): RichColor = new RichColor(c)
 
   def fromHSB(hue: Double, saturation: Double, brightness: Double): Color = {
     Color.getHSBColor(hue.toFloat, saturation.toFloat, brightness.toFloat)

--- a/src/main/scala/scalaswingcontrib/RichFont.scala
+++ b/src/main/scala/scalaswingcontrib/RichFont.scala
@@ -13,5 +13,5 @@ class RichFont(font: Font) {
 }
 object RichFont {
   
-  implicit def font2RichFont(f: Font) = new RichFont(f)
+  implicit def font2RichFont(f: Font): RichFont = new RichFont(f)
 }

--- a/src/main/scala/scalaswingcontrib/TransferHandlerRow.scala
+++ b/src/main/scala/scalaswingcontrib/TransferHandlerRow.scala
@@ -19,7 +19,7 @@ trait ClipboardCallbacks {
 }
 
 trait Reorderable {
-  def reorder(from: Int, to: Int)
+  def reorder(from: Int, to: Int): Unit
 }
 
 object RowTransferable {
@@ -42,7 +42,7 @@ abstract class TransferRowContainer[Table: ClassTag, DropLocation: ClassTag] {
   def isContainer(c: java.awt.Component): Boolean
   def container: Table
   def selectedRow: Int
-  def setCursor(cursor: Cursor)
+  def setCursor(cursor: Cursor): Unit
 
   def handleDrop(rowFrom: RowTransferable, dl: DropLocation): Boolean
 }
@@ -92,7 +92,7 @@ class TransferHandlerRow[Table: ClassTag, DropLocation: ClassTag](
     exportDone(comp, null, TransferHandler.NONE)
   }
 
-  protected override def exportDone(c: JComponent, t: Transferable, act: Int) {
+  protected override def exportDone(c: JComponent, t: Transferable, act: Int): Unit = {
     act match {
       case TransferHandler.MOVE =>
         container.setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR))

--- a/src/main/scala/scalaswingcontrib/group/ComponentsInGroups.scala
+++ b/src/main/scala/scalaswingcontrib/group/ComponentsInGroups.scala
@@ -14,7 +14,7 @@ trait ComponentsInGroups extends SizeTypes { this: GroupPanel =>
   /**
    * Implicit conversion that puts a component into the correct context on demand.
    */
-  protected final implicit def add[A <: G](comp: Component) =
+  protected final implicit def add[A <: G](comp: Component): ComponentInGroup[A] =
     new ComponentInGroup[A](comp)
   
   /** Triplet of minimum, preferred and maximum size. */

--- a/src/main/scala/scalaswingcontrib/group/GroupPanel.scala
+++ b/src/main/scala/scalaswingcontrib/group/GroupPanel.scala
@@ -300,12 +300,12 @@ class GroupPanel extends Panel
   autoCreateContainerGaps = true
   
   /** Starting point for the horizontal layout. */
-  val theHorizontalLayout = new {
+  object theHorizontalLayout {
     def is(group: Group) = layout.setHorizontalGroup(group.buildChildren)
   }
   
   /** Starting point for the vertical layout. */
-  val theVerticalLayout = new {
+  object theVerticalLayout {
     def is(group: Group) = layout.setVerticalGroup(group.buildChildren)
   }  
 }

--- a/src/main/scala/scalaswingcontrib/group/Groups.scala
+++ b/src/main/scala/scalaswingcontrib/group/Groups.scala
@@ -50,11 +50,11 @@ trait Groups
   }
   
   /** Implicit conversion that puts a group into the correct context on demand. */
-  protected final implicit def groupInSequential(grp: Group) =
+  protected final implicit def groupInSequential(grp: Group): GroupInSequential =
     new GroupInSequential(grp, None)
   
   /** Implicit conversion that puts a group into the correct context on demand. */
-  protected final implicit def groupInParallel(grp: Group) =
+  protected final implicit def groupInParallel(grp: Group): GroupInParallel =
     new GroupInParallel(grp, None)
       
   /**

--- a/src/main/scala/scalaswingcontrib/test/TreeDemo.scala
+++ b/src/main/scala/scalaswingcontrib/test/TreeDemo.scala
@@ -21,7 +21,7 @@ object TreeDemo extends SimpleSwingApplication {
   // Use case 1: Show an XML document
   lazy val xmlTree = new Tree[Node] {
     model = TreeModel(xmlDoc)(_.child filterNot (_.text.trim.isEmpty))
-    renderer = Renderer(n => 
+    renderer = Renderer[Node, String]((n) =>
         if (n.label startsWith "#") n.text.trim 
         else n.label)
         
@@ -36,7 +36,7 @@ object TreeDemo extends SimpleSwingApplication {
       else Seq()
     }
     
-    renderer = Renderer.labeled { f =>
+    renderer = Renderer.labeled[File] { f =>
       val icon = if (f.isDirectory) folderIcon 
                  else fileIcon
       (icon, f.getName)
@@ -121,7 +121,7 @@ object TreeDemo extends SimpleSwingApplication {
       case TreeNodeSelected(node) => externalTreeStatusBar.text = "Selected: " + node
     }
     
-    renderer = Renderer.labeled { f =>
+    renderer = Renderer.labeled[PretendFile] { f =>
       val icon = if (f.isDirectory) folderIcon 
                  else fileIcon
       (icon, f.name)
@@ -312,7 +312,7 @@ object TreeDemo extends SimpleSwingApplication {
 
       def copy(): PretendFile = {
         // no need to copy children, this is in fact a move, not a copy
-        val ret = PretendFile(nameVar, childBuffer: _*)
+        val ret = PretendFile(nameVar, childBuffer.toSeq: _*)
         // but we need to notify them about a new parent
         ret.childBuffer foreach (_.parent = Some(ret))
         ret

--- a/src/main/scala/scalaswingcontrib/tree/ExternalTreeModel.scala
+++ b/src/main/scala/scalaswingcontrib/tree/ExternalTreeModel.scala
@@ -292,7 +292,7 @@ class ExternalTreeModel[A: ClassTag](rootItems: collection.Seq[A], children: A =
    * This implementation of javax.swing.tree.TreeModel takes advantage of its abstract nature, so that it respects 
    * the tree shape of the underlying structure provided by the user.
    */
-  lazy val peer = new ExternalTreeModelPeer
+  lazy val peer: ExternalTreeModelPeer = new ExternalTreeModelPeer
    
 }
 

--- a/src/main/scala/scalaswingcontrib/tree/TreeModel.scala
+++ b/src/main/scala/scalaswingcontrib/tree/TreeModel.scala
@@ -22,7 +22,7 @@ object TreeModel {
 trait TreeModel[A] {
   
   def roots: collection.Seq[A]
-  val peer: jst.TreeModel 
+  def peer: jst.TreeModel
   def getChildrenOf(parentPath: Path[A]): collection.Seq[A]
   def getChildPathsOf(parentPath: Path[A]): collection.Seq[Path[A]] = getChildrenOf(parentPath).map(parentPath :+ _)
   def filter(p: A => Boolean): TreeModel[A]


### PR DESCRIPTION
This PR makes necessary changes to cross-compile on Scala 3.

While Scala 3 projects can use 2.13 libraries, this is problematic because of transitional dependencies to things like _scala-xml_.

Support for Scala 2.11 was dropped because of _specs2_, which does not exist in a version which is available for both 2.11 and 3.x.