### PR TITLE
Add javax.activation - deprecated since Java 9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,8 @@ libraryDependencies ++= Seq(
 
   "org.scala-lang.modules" %% "scala-collection-compat" % "2.7.0",
 
+  "com.sun.activation" % "javax.activation" % "1.2.0", // clipboard data handlers - deprecated in SDK in Java 9, removed later
+
   "org.specs2" %% "specs2-core" % "4.15.0" % Test,
   "org.specs2" %% "specs2-junit" % "4.15.0" % Test,
 


### PR DESCRIPTION
#22 continued - Fix compile error with JDK > 9